### PR TITLE
Fix incompatible types

### DIFF
--- a/src/Connection.php
+++ b/src/Connection.php
@@ -11,28 +11,4 @@ use BinSoul\Net\Mqtt\Message;
 interface Connection extends BaseConnection
 {
     public function toThrift(): string;
-
-    public function getProtocol(): int;
-
-    public function getClientID(): string;
-
-    public function isCleanSession(): bool;
-
-    public function getUsername(): string;
-
-    public function getPassword(): string;
-
-    public function getWill(): ?Message;
-
-    public function getKeepAlive(): int;
-
-    public function withProtocol(int $protocol): BaseConnection;
-
-    public function withClientID(string $clientID): BaseConnection;
-
-    public function withCredentials(string $username, string $password): BaseConnection;
-
-    public function withWill(Message $will = null): BaseConnection;
-
-    public function withKeepAlive(int $timeout): BaseConnection;
 }

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -5,8 +5,6 @@ declare(strict_types=1);
 namespace Fbns;
 
 use BinSoul\Net\Mqtt\Connection as BaseConnection;
-use BinSoul\Net\Mqtt\Message;
-
 
 interface Connection extends BaseConnection
 {

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -5,8 +5,34 @@ declare(strict_types=1);
 namespace Fbns;
 
 use BinSoul\Net\Mqtt\Connection as BaseConnection;
+use BinSoul\Net\Mqtt\Message;
+
 
 interface Connection extends BaseConnection
 {
     public function toThrift(): string;
+
+    public function getProtocol(): int;
+
+    public function getClientID(): string;
+
+    public function isCleanSession(): bool;
+
+    public function getUsername(): string;
+
+    public function getPassword(): string;
+
+    public function getWill(): ?Message;
+
+    public function getKeepAlive(): int;
+
+    public function withProtocol(int $protocol): BaseConnection;
+
+    public function withClientID(string $clientID): BaseConnection;
+
+    public function withCredentials(string $username, string $password): BaseConnection;
+
+    public function withWill(Message $will = null): BaseConnection;
+
+    public function withKeepAlive(int $timeout): BaseConnection;
 }

--- a/src/Mqtt/RtiConnection.php
+++ b/src/Mqtt/RtiConnection.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Fbns\Mqtt;
 
 use BinSoul\Net\Mqtt\Message;
+use BinSoul\Net\Mqtt\Connection as BaseConnection;
 use Fbns\Auth;
 use Fbns\Connection;
 use Fbns\Device;
@@ -119,27 +120,27 @@ class RtiConnection implements Connection
         return self::KEEPALIVE_INTERVAL;
     }
 
-    public function withProtocol(int $protocol): Connection
+    public function withProtocol(int $protocol): BaseConnection
     {
         throw new \LogicException('Protocol version can not be changed.');
     }
 
-    public function withClientID(string $clientID): Connection
+    public function withClientID(string $clientID): BaseConnection
     {
         throw new \LogicException('Client ID must be changed via Auth.');
     }
 
-    public function withCredentials(string $username, string $password): Connection
+    public function withCredentials(string $username, string $password): BaseConnection
     {
         throw new \LogicException('Credentials must be changed via Auth.');
     }
 
-    public function withWill(Message $will = null): Connection
+    public function withWill(Message $will = null): BaseConnection
     {
         throw new \LogicException('Will is not supported.');
     }
 
-    public function withKeepAlive(int $timeout): Connection
+    public function withKeepAlive(int $timeout): BaseConnection
     {
         throw new \LogicException('Keep alive interval can not be changed.');
     }

--- a/src/Mqtt/RtiConnection.php
+++ b/src/Mqtt/RtiConnection.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Fbns\Mqtt;
 
-use BinSoul\Net\Mqtt\Message;
 use BinSoul\Net\Mqtt\Connection as BaseConnection;
+use BinSoul\Net\Mqtt\Message;
 use Fbns\Auth;
 use Fbns\Connection;
 use Fbns\Device;


### PR DESCRIPTION
Hello @valga,

This PR fixes some incompatible types:


`Fatal error: Declaration of Fbns\Mqtt\RtiConnection::withProtocol(int $protocol): Fbns\Connection must be compatible with BinSoul\Net\Mqtt\Connection::withProtocol(int $protocol): BinSoul\Net\Mqtt\Connection in /Users/mgp25/Documents/GitHub/Instagram/vendor/valga/fbns-react/src/Mqtt/RtiConnection.php on line 17`

If this is pushed, creating a new release `0.2.1` would be great.

Best regards